### PR TITLE
Agent teams support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,7 +14,8 @@
     "planning",
     "TDD",
     "workflow",
-    "subagents"
+    "subagents",
+    "agent-teams"
   ],
   "agents": [
     "./agents/context-explorer.md",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "conductor",
   "description": "Conductor: Context-driven development for Claude Code - Measure twice, code once",
-  "version": "0.3.0",
+  "version": "0.2.2",
   "license": "MIT",
   "author": {
     "name": "Javokhirbek | TenXEngineer",
@@ -14,8 +14,7 @@
     "planning",
     "TDD",
     "workflow",
-    "subagents",
-    "agent-teams"
+    "subagents"
   ],
   "agents": [
     "./agents/context-explorer.md",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "conductor",
   "description": "Conductor: Context-driven development for Claude Code - Measure twice, code once",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "MIT",
   "author": {
     "name": "Javokhirbek | TenXEngineer",
@@ -14,7 +14,8 @@
     "planning",
     "TDD",
     "workflow",
-    "subagents"
+    "subagents",
+    "agent-teams"
   ],
   "agents": [
     "./agents/context-explorer.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,6 @@ All notable changes to Conductor for Claude Code will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-02-24
-
-### Added
-
-- **Agent Teams Support (Experimental)**
-  - Added `--team` flag to `/conductor:implement` to orchestrate parallel work using Claude Code's Agent Teams feature.
-  - Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
-  - Automatically spawns teammates based on the track's plan.
-
 ## [0.2.2] - 2025-12-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Conductor for Claude Code will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-24
+
+### Added
+
+- **Agent Teams Support (Experimental)**
+  - Added `--team` flag to `/conductor:implement` to orchestrate parallel work using Claude Code's Agent Teams feature.
+  - Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+  - Automatically spawns teammates based on the track's plan.
+
 ## [0.2.2] - 2025-12-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ When Conductor is set up, it creates these context files in `conductor/`:
 | ---------------------- | ----------------------------------------------------- |
 | `/conductor:setup`     | Initialize the Conductor environment for your project |
 | `/conductor:new-track` | Create a new feature/bug track with spec and plan     |
-| `/conductor:implement` | Execute tasks from a track's plan                     |
+| `/conductor:implement` | Execute tasks from a track's plan (use `--team` for Agent Teams) |
 | `/conductor:status`    | Display current project progress                      |
 | `/conductor:revert`    | Git-aware revert of tracks, phases, or tasks          |
 
@@ -49,6 +49,17 @@ In `plan.md` and `tracks.md` files:
 - `[ ]` - Pending (not started)
 - `[~]` - In Progress
 - `[x]` - Completed (with commit SHA appended)
+
+## Agent Teams (Experimental)
+
+Conductor supports Claude Code's **Agent Teams** feature for parallel implementation of complex tracks. This feature allows multiple autonomous agents to work together on different parts of a track (e.g., frontend, backend, QA) simultaneously.
+
+### Prerequisites
+- Enable Agent Teams: `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+
+### Usage
+- Run `/conductor:implement --team` to enable the Agent Team mode.
+- Conductor will act as the Team Lead, spawning specialized teammates based on the track's plan.
 
 ## Subagents for Context Hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ Conductor supports Claude Code's **Agent Teams** feature for parallel implementa
 
 ### Usage
 - Run `/conductor:implement --team` to enable the Agent Team mode.
-- Conductor will act as the Team Lead, spawning specialized teammates based on the track's plan.
+- If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is not set, the command will halt with an error message directing you to enable the feature.
+- When enabled, Conductor acts as the Team Lead, spawning specialized teammates (e.g., Frontend, Backend, QA) based on the track's plan using Claude Code's native agent orchestration capabilities.
 
 ## Subagents for Context Hygiene
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -52,8 +52,64 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
 ---
 
-## 3.0 TRACK IMPLEMENTATION
-**PROTOCOL: Execute the selected track.**
+## 3.0 IMPLEMENTATION MODE
+**PROTOCOL: Determine the execution mode (Standard or Team).**
+
+1.  **Check for `--team` Flag:**
+    -   Check if the user invoked the command with the `--team` argument (e.g., `/conductor:implement --team`).
+
+2.  **Branch Logic:**
+    -   **If `--team` is detected:**
+        -   **Verify Agent Teams Feature:** Check if `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable is set to `1` by running `echo $CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`.
+        -   **If enabled:** Proceed to **3.1 TEAM ORCHESTRATION**.
+        -   **If disabled:** Announce: "Agent Teams are currently disabled. To use the `--team` flag, please enable them by running `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`." and halt.
+    -   **If `--team` is NOT detected:**
+        -   Proceed to **3.2 STANDARD IMPLEMENTATION**.
+
+---
+
+## 3.1 TEAM ORCHESTRATION (EXPERIMENTAL)
+**PROTOCOL: Form and lead the agent team.**
+
+1.  **Announce Action:** Announce that you are starting the track implementation using an Agent Team.
+
+2.  **Update Status to 'In Progress':**
+    -   Update the track status in `conductor/tracks.md` to `[~]` (In Progress).
+
+3.  **Load Track Context:**
+    -   Identify the track folder link from `conductor/tracks.md`.
+    -   Read the content of `conductor/tracks/<track_id>/plan.md`, `conductor/tracks/<track_id>/spec.md`, `conductor/tech-stack.md`, and `conductor/workflow.md`.
+
+4.  **Analyze and Form Team:**
+    -   Analyze the `plan.md` to determine the necessary roles for parallel execution.
+    -   **CRITICAL:** You MUST now spawn the agent team using your natural language capabilities.
+    -   **Instruction to Agent:** "Spawn an agent team with the following structure based on the plan. Assign them specific responsibilities."
+    -   **Example Prompt Structure:**
+        > "Create an agent team to implement the track '<track_description>'.
+        > Spawn the following teammates:
+        > - [Role 1]: [Description of responsibility]
+        > - [Role 2]: [Description of responsibility]
+        > - QA Specialist: To verify the implementation against spec.md.
+        >
+        > Assign tasks from the `plan.md` to the teammates. Coordinate their work, ensure they follow the `tech-stack.md` and `workflow.md`, and synthesize their results."
+
+5.  **Manage Execution:**
+    -   As the Team Lead, your job is to:
+        -   Assign tasks to teammates.
+        -   Review their outputs.
+        -   Resolve conflicts.
+        -   Ensure the implementation matches the `spec.md`.
+
+6.  **Finalize:**
+    -   Once all tasks are complete and verified:
+        -   Update the track status in `conductor/tracks.md` to `[x]`.
+        -   Announce completion.
+        -   Proceed to **6.0 SYNCHRONIZE PROJECT DOCUMENTATION**.
+
+---
+
+## 3.2 STANDARD IMPLEMENTATION
+**PROTOCOL: Execute the selected track sequentially.**
 
 1.  **Announce Action:** Announce which track you are beginning to implement.
 
@@ -79,6 +135,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
     -   After all tasks in the track's local `plan.md` are completed, you MUST update the track's status in the tracks file.
     -   This requires finding the specific heading for the track (e.g., `## [~] Track: <Description>`) and replacing it with the completed status (e.g., `## [x] Track: <Description>`).
     -   Announce that the track is fully complete and the tracks file has been updated.
+    -   Proceed to **6.0 SYNCHRONIZE PROJECT DOCUMENTATION**.
 
 ---
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -82,8 +82,8 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
 4.  **Analyze and Form Team:**
     -   Analyze the `plan.md` to determine the necessary roles for parallel execution.
-    -   **CRITICAL:** You MUST now spawn the agent team using your natural language capabilities.
-    -   **Instruction to Agent:** "Spawn an agent team with the following structure based on the plan. Assign them specific responsibilities."
+    -   **CRITICAL:** You MUST now issue a prompt to Claude Code to spawn the agent team. Do NOT simulate this internally; use the native agent orchestration capabilities.
+    -   **Instruction to Agent:** "Create an agent team with the following structure based on the plan. Assign them specific responsibilities."
     -   **Example Prompt Structure:**
         > "Create an agent team to implement the track '<track_description>'.
         > Spawn the following teammates:


### PR DESCRIPTION
## Summary by Sourcery

Add experimental Agent Teams support to the Conductor implement flow, introducing a team-based execution mode alongside the existing sequential implementation mode.

New Features:
- Introduce an experimental Agent Team implementation mode that orchestrates multiple specialized agents in parallel for track execution.
- Add a `--team` flag to `/conductor:implement` to trigger Agent Team mode when the Agent Teams feature is enabled via environment variable.
- Define Conductor's role as Team Lead for Agent Teams, including task assignment, coordination, and verification against the track spec.

Enhancements:
- Clarify the standard implementation flow and explicitly route both team and standard modes to the documentation synchronization step.
- Update CLI command documentation to describe the new Agent Teams capability and usage prerequisites.

Documentation:
- Document the experimental Agent Teams feature, including prerequisites, usage of `/conductor:implement --team`, and Conductor's coordination behavior.